### PR TITLE
Fix verify-poll strike semantics: builds stuck in tasks_running after CI failure

### DIFF
--- a/app/models/shipit/predictive_branch.rb
+++ b/app/models/shipit/predictive_branch.rb
@@ -113,18 +113,20 @@ module Shipit
 
       unless [:success, :pending, :running].include? task_status
         return run_task_failed(task) if predictive_task_type == :run
-        # Verify tasks are idempotent status polls — a dead/errored poll says
-        # nothing about the CI itself (real failures arrive via successful
-        # polls reporting :aborted below). Tolerate a few strikes; the next
-        # cron tick re-polls anyway.
-        if predictive_task_type == :verify
+        # Only a LOST poll (reaped as zombie => :error, hung => :timedout) is
+        # tolerated with strikes — it says nothing about the CI itself and the
+        # next cron tick re-polls anyway. A :failed poll is the script exiting
+        # non-zero on a real CI failure and must fail the run immediately.
+        if predictive_task_type == :verify && [:error, :timedout].include?(task_status)
           return task_failed if verify_poll_strike! > MAX_VERIFY_POLL_STRIKES
           Rails.logger.warn("Predictive branch #{id}: verify task #{task.id} ended #{task_status}, keeping status and waiting for next poll")
           return
         end
         return task_failed
       end
-      clear_verify_poll_strikes if predictive_task_type == :verify
+      # Only a completed successful poll proves the CI is healthy; a freshly
+      # created (:pending) task must not reset the consecutive-failure count.
+      clear_verify_poll_strikes if predictive_task_type == :verify && task_status == :success
 
 
       if predictive_task_type == :run

--- a/app/models/shipit/predictive_build.rb
+++ b/app/models/shipit/predictive_build.rb
@@ -202,16 +202,20 @@ module Shipit
       end
 
       unless [:success, :pending, :running].include? pipeline_task_status
-        return pipeline_task_failed unless predictive_task_type == :verify
-        # A verify task is an idempotent status poll: losing one (worker died,
-        # reaped as zombie, transient error) says nothing about the CI itself —
-        # real CI failures arrive via successful polls reporting :aborted below.
-        # Tolerate a few dead polls; the next cron tick re-polls anyway.
-        return pipeline_task_failed if verify_poll_strike! > MAX_VERIFY_POLL_STRIKES
-        Rails.logger.warn("Predictive build #{id}: verify task #{task.id} ended #{pipeline_task_status}, keeping CI status and waiting for next poll")
-        return
+        # Only a LOST poll (reaped as zombie => :error, hung => :timedout) is
+        # tolerated with strikes — it says nothing about the CI itself and the
+        # next cron tick re-polls anyway. A :failed poll is the script exiting
+        # non-zero on a real CI failure and must fail the run immediately.
+        if predictive_task_type == :verify && [:error, :timedout].include?(pipeline_task_status)
+          return pipeline_task_failed if verify_poll_strike! > MAX_VERIFY_POLL_STRIKES
+          Rails.logger.warn("Predictive build #{id}: verify task #{task.id} ended #{pipeline_task_status}, keeping CI status and waiting for next poll")
+          return
+        end
+        return pipeline_task_failed
       end
-      clear_verify_poll_strikes if predictive_task_type == :verify
+      # Only a completed successful poll proves the CI is healthy; a freshly
+      # created (:pending) task must not reset the consecutive-failure count.
+      clear_verify_poll_strikes if predictive_task_type == :verify && pipeline_task_status == :success
 
       if predictive_task_type == :run
         ci_pipeline_running       if pipeline_task_status == :running || pipeline_task_status == :pending


### PR DESCRIPTION
## Bug (integration, introduced by #82)

After a real CI failure, builds looped forever in `tasks_running` (e.g. integration builds 46102/46104/46105/46106, stuck up to 19h), and since a WIP build blocks its pipeline, new PRs piled up behind them — "stuck in queue".

Root cause, two compounding flaws in the #82 strike logic:

1. **A `:failed` poll is a real CI failure, not a dead poll** — `get_job_status.py` exits 1 when the Jenkins job status is FAILURE. #82 sent those into the strike counter instead of failing the run immediately.
2. **The strike counter was reset every minute** — `update_status` also runs when the tick *creates* the next verify task (status `:pending`, in the healthy list), which cleared the strikes, so the ceiling of 4 could never fire.

## Fix

- Strikes now apply **only** to genuinely lost polls: `:error` (zombie-reaped — the original production incident) and `:timedout` (hung). 
- `:failed` polls and the no-match strikeout return to their pre-#82 fail-fast behavior.
- Strikes are cleared **only by a successfully completed poll**, not by freshly created pending tasks.

## Aftermath

Stuck builds self-heal after deploy: their next failed poll tears the run down properly and rejected PRs get their comment. No manual cleanup needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)