### PR TITLE
Report pipeline CI failures instead of the generic teardown message

### DIFF
--- a/app/models/shipit/predictive_branch.rb
+++ b/app/models/shipit/predictive_branch.rb
@@ -233,6 +233,17 @@ module Shipit
         failed_branches << p_build_branch if p_build_branch.failed?
       end
       if failed_branches.empty?
+        # No project's own CI failed. If the pipeline-level CI (e.g.
+        # common_automation) failed, say so instead of the generic message —
+        # otherwise developers retry blind on a real, reproducible failure.
+        if predictive_build.ci_pipeline_failed?
+          msg = ["Failed to process your request due to a pipeline CI failure, while your repository's own CI passed."]
+          predictive_build.ci_jobs_statuses.each do |job|
+            msg << "* #{job.name}: #{job.status} - #{job.link}"
+          end
+          msg << "This can be caused by your changes or by another PR in the same CI cycle. Check the failed job above, then `/shipit` again."
+          return msg.join("\n")
+        end
         return "Something went wrong, please start over."
       end
       res = []


### PR DESCRIPTION
## Why

When pipeline-level CI (common_automation) fails but every project's own CI passed, `additional_failed_information` falls through to "Something went wrong, please start over." — a real, reproducible failure rendered as noise. Concrete cost: vcita/automation-js#2324 failed the automation suite identically three times over six days (common_automation #50660, #50668, #50841 — all `status:FAILURE`), and the developer retried blind each time because the comment never said what failed.

## What

In the no-failed-branches case, if `predictive_build.ci_pipeline_failed?`, the rejection comment now lists the pipeline CI jobs with status and Jenkins link (from `ci_jobs_statuses`, already populated by the polls) plus a retry hint. The generic message remains for teardowns with genuinely unknown cause.

One string branch, no behavioral change to teardown logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)